### PR TITLE
SEO: Meta-Tags, OG/Twitter Cards, JSON-LD, Sitemap-Optimierung

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,10 @@ Guidance for humans and coding agents working in this repository.
 
 Marketing site for **Triarc Laboratories** ([triarc-labs.com](https://triarc-labs.com), dev: [dev.triarc-labs.com](https://dev.triarc-labs.com/)).
 
-| Part | Role |
-|------|------|
-| **Root (`/`)** | SvelteKit 2 + Svelte 4 frontend, deployed with `@sveltejs/adapter-vercel` |
-| **`api/`** | Separate NestJS service (chat, email, file storage) — not started by `npm run dev` in the root |
+| Part           | Role                                                                                           |
+| -------------- | ---------------------------------------------------------------------------------------------- |
+| **Root (`/`)** | SvelteKit 2 + Svelte 4 frontend, deployed with `@sveltejs/adapter-vercel`                      |
+| **`api/`**     | Separate NestJS service (chat, email, file storage) — not started by `npm run dev` in the root |
 
 Most pages are **static TypeScript content** composed with shared UI. **Projects**, **stories**, and some listing pages load data from **Ghost** (`blog.triarc-labs.com`). Forms and live chat call **`chatbot.triarc-labs.com`**.
 
@@ -35,15 +35,15 @@ Path alias: **`$lib`** → `src/lib` (see `svelte.config.js` / Kit defaults).
 
 From repository root:
 
-| Command | Purpose |
-|---------|---------|
-| `npm install` | Install frontend dependencies |
-| `npm run dev` | Vite dev server (SvelteKit) |
-| `npm run build` | Production build |
+| Command           | Purpose                          |
+| ----------------- | -------------------------------- |
+| `npm install`     | Install frontend dependencies    |
+| `npm run dev`     | Vite dev server (SvelteKit)      |
+| `npm run build`   | Production build                 |
 | `npm run preview` | Preview production build locally |
-| `npm run check` | `svelte-check` + sync (types) |
-| `npm run lint` | Prettier check + ESLint |
-| `npm run format` | Prettier write |
+| `npm run check`   | `svelte-check` + sync (types)    |
+| `npm run lint`    | Prettier check + ESLint          |
+| `npm run format`  | Prettier write                   |
 
 For **`api/`**: `npm install` and `npm run start` (Nest watch) inside `api/` when changing backend behavior.
 
@@ -126,14 +126,14 @@ Remote is **GitHub** (`triarc/website`); team may track work in GitLab issues �
 
 ## Common tasks (quick reference)
 
-| Task | Where to look |
-|------|----------------|
-| New static service page | `custom-software/+page.svelte`, `$lib/content/*-section.ts` |
-| Ghost project detail | `projects/[slug]/+page.ts`, `ghost-helpers.ts` |
-| Stories / blog listing | `stories/+page.ts`, `stories/[slug]/+page.ts` |
-| Jobs | `jobs/[slug]/`, `ApplicationForm.svelte`, `$lib/content/application-process.ts` |
-| Sitemap | `routes/sitemap.xml/+server.ts` |
-| Chat / contact submit | `api/src/chat.*`, frontend `*Form.svelte` / `LiveChat.svelte` |
+| Task                    | Where to look                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| New static service page | `custom-software/+page.svelte`, `$lib/content/*-section.ts`                     |
+| Ghost project detail    | `projects/[slug]/+page.ts`, `ghost-helpers.ts`                                  |
+| Stories / blog listing  | `stories/+page.ts`, `stories/[slug]/+page.ts`                                   |
+| Jobs                    | `jobs/[slug]/`, `ApplicationForm.svelte`, `$lib/content/application-process.ts` |
+| Sitemap                 | `routes/sitemap.xml/+server.ts`                                                 |
+| Chat / contact submit   | `api/src/chat.*`, frontend `*Form.svelte` / `LiveChat.svelte`                   |
 
 ## Optional: Cursor rules
 

--- a/src/lib/components/ApplicationForm.svelte
+++ b/src/lib/components/ApplicationForm.svelte
@@ -471,7 +471,7 @@
                         for="condition-checkbox"
                         class="inline pl-4 text-wrap text-s font-medium text-gray-900 decoration-red-triarc"
                       >
-                        Wir akzeptieren keine Bewerbungen über Personalvermittlern oder Headhuntern. Ich bestätige, dass
+                        Wir akzeptieren keine Bewerbungen über Personalvermittler oder Headhunter. Ich bestätige, dass
                         ich mich direkt bewerbe.
                       </label>
                     </div>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -5,7 +5,7 @@
         <h1 class="text-xl">
           <slot />
         </h1>
-        <p class="text-sm">Hautpseite</p>
+        <p class="text-sm">Hauptseite</p>
       </div>
       <img src="/icons/triarc-logo.svg" class="h-10" alt="triarc logo" />
     </a>

--- a/src/lib/components/MetaHead.svelte
+++ b/src/lib/components/MetaHead.svelte
@@ -3,16 +3,38 @@
   import { page } from '$app/stores'
 
   export let pageMetadata: TriarcPageMetadata
+
+  const siteName = 'triarc laboratories Ltd.'
+  const fallbackOgImage = 'https://triarc-labs.com/triarc-og-default.png'
+
+  $: canonicalUrl = pageMetadata.canonicalUrl ?? $page.url.href
+  $: pageTitle = pageMetadata.metaTitle ?? pageMetadata.title
+  $: pageDescription = pageMetadata.description
+  $: ogImage = pageMetadata.ogImage ?? fallbackOgImage
 </script>
 
 <svelte:head>
   <title>{pageMetadata.title}</title>
 
-  <meta property="title" content={pageMetadata.metaTitle ?? pageMetadata.title} />
-  <meta name="description" content={pageMetadata.description} />
+  <meta name="description" content={pageDescription} />
 
-  <meta property="og:url" content={$page.url.href} />
-  <meta property="og:site_name" content="triarc laboratories Ltd." />
-  <meta property="og:title" content={pageMetadata.metaTitle ?? pageMetadata.title} />
-  <meta property="og:description" content={pageMetadata.description} />
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content={canonicalUrl} />
+  <meta property="og:site_name" content={siteName} />
+  <meta property="og:title" content={pageTitle} />
+  <meta property="og:description" content={pageDescription} />
+  <meta property="og:image" content={ogImage} />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:locale" content="de_CH" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content={pageTitle} />
+  <meta name="twitter:description" content={pageDescription} />
+  <meta name="twitter:image" content={ogImage} />
+
+  <!-- Canonical -->
+  <link rel="canonical" href={canonicalUrl} />
 </svelte:head>

--- a/src/lib/components/NotFound.svelte
+++ b/src/lib/components/NotFound.svelte
@@ -1,6 +1,6 @@
 <div class="bg-gray-800 h-screen w-full flex flex-col justify-center items-center">
   <div class="text-gray-700 font-thin not-found">404</div>
-  <span class="text-white">Oops, leider haben wir hier nichts</span>
+  <span class="text-white">Ups, leider haben wir hier nichts</span>
   <span class="text-gray-400"
     >Melde uns das Problem auf unserem <a class="underline" href="https://github.com/triarc/website/issues"
       >GitHub Repo</a
@@ -11,7 +11,7 @@
     <span class="text-4xl text-white my-6">ODER</span>
     <hr class="w-32 ml-6" />
   </div>
-  <a href="/" class="bg-white text-gray-600 rounded-full px-6 py-3">gehe zur Startseite</a>
+  <a href="/" class="bg-white text-gray-600 rounded-full px-6 py-3">Zur Startseite</a>
 </div>
 
 <style style lang="postcss">

--- a/src/lib/components/TypeDefinitions.ts
+++ b/src/lib/components/TypeDefinitions.ts
@@ -217,4 +217,7 @@ export interface TriarcPageMetadata {
   title: string
   metaTitle?: string
   description: string
+  ogImage?: string
+  /** Canonical URL – falls abweichend von der aktuellen Seiten-URL */
+  canonicalUrl?: string
 }

--- a/src/lib/content/triarc-page-metadata.ts
+++ b/src/lib/content/triarc-page-metadata.ts
@@ -1,85 +1,100 @@
 import type { TriarcPageMetadata } from '$lib/components/TypeDefinitions'
 
 export const consultingMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Digitalisierungsberatung – triarc laboratories',
+  metaTitle: 'Beratung für Ihre digitale Transformation',
+  description:
+    'Erfolgreiche Digitalisierung braucht das Miteinander. Wir begleiten Ihre digitale Transformation mit Strategie, Change Management und Prozessoptimierung – ganzheitlich und nachhaltig.',
 }
 
 export const contactMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Kontakt – triarc laboratories',
+  metaTitle: 'Kontaktieren Sie triarc laboratories in Zürich',
+  description:
+    'Sie haben eine Idee oder ein Projekt? Sprechen Sie mit uns. triarc laboratories – Custom Software, Beratung und Innovation aus Zürich.',
 }
 
 export const customSoftwareMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Custom Software Entwicklung – triarc laboratories',
+  metaTitle: 'Massgeschneiderte Softwareentwicklung aus Zürich',
+  description:
+    'Wir entwickeln Custom Software, die exakt zu Ihren Bedürfnissen passt. Agile Entwicklung, Wartung und Hosting aus einer Hand – seit über 10 Jahren.',
 }
 
 export const futureMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Wettbewerbsfähigkeit – triarc laboratories',
+  metaTitle: 'Zukünftige Wettbewerbsfähigkeit sichern',
+  description:
+    'Skalierbare Lösungen, agile Strukturen und gezielte Innovation stärken Ihre Wettbewerbsfähigkeit und ermöglichen eine klare Positionierung mit einem einzigartigen USP.',
 }
 
 export const innovationMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Innovation Lab – triarc laboratories',
+  metaTitle: 'Innovation Lab: Produkte und MVPs entwickeln',
+  description:
+    'In unserem Innovation Lab fördern wir wettbewerbsfähige Businessideen, erstellen Machbarkeitsanalysen und entwickeln MVPs. Von Voice Reporting bis Terminfindung.',
 }
 
 export const jobsMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Jobs – triarc laboratories',
+  metaTitle: 'Karriere bei triarc laboratories in Zürich',
+  description:
+    'Werde Teil unseres Teams. Wir suchen motivierte Softwareentwickler:innen und Talente für Custom Software, Innovation und Beratung in Zürich.',
 }
 
 export const labMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Innovation Lab Projekte – triarc laboratories',
+  metaTitle: 'Innovation Lab: Slothi, Fair Pizza & mehr',
+  description:
+    'Entdecken Sie unsere Lab-Projekte: Slothi Terminfindung, Fair Pizza Whitelabel-Shop und weitere innovative Produkte aus dem Hause triarc.',
 }
 
 export const missionMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Together you succeed – triarc laboratories',
+  metaTitle: 'Unsere Mission: Together you succeed',
+  description:
+    'Für Ihren Fortschritt. Wir entwickeln massgeschneiderte Software, begleiten Ihre digitale Transformation und fördern Innovation – alles aus einer Hand in Zürich.',
 }
 
 export const mlinkMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'μLink Datahub – triarc laboratories',
+  metaTitle: 'μLink: Echtzeit-Datenhub für Ihr Software-Ökosystem',
+  description:
+    'μLink vernetzt ERP, CRM, Disposition und mehr in Echtzeit. Die Schnittstellenlösung für ein integriertes Software-Ökosystem ohne Medienbrüche.',
 }
 
 export const operationsMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Operations – triarc laboratories',
+  metaTitle: 'Operativen Reibungsverlust reduzieren',
+  description:
+    'Automatisierte Abläufe, intuitive Bedienung und gezielter Wissenstransfer sorgen für reibungslose Zusammenarbeit und eine starke operative Performance.',
 }
 
 export const storiesMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Stories – triarc laboratories',
+  metaTitle: 'Neues von triarc laboratories',
+  description:
+    'Erfahren Sie mehr über unsere Projekte, Erfolgsgeschichten und was uns bewegt. Stories aus dem triarc-Universum rund um Custom Software und digitale Transformation.',
 }
 
 export const strategyMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Strategie – triarc laboratories',
+  metaTitle: 'Strategie in die Praxis übersetzen',
+  description:
+    'Mit klaren Entscheidungsgrundlagen und einem ganzheitlichen Ansatz schaffen wir die Basis, damit Veränderungen zielgerichtet, effizient und nachhaltig wirken.',
 }
 
 export const teamMetadata: TriarcPageMetadata = {
-  title: '',
-  metaTitle: '',
-  description: '',
+  title: 'Team – triarc laboratories',
+  metaTitle: 'Unser Team: Erfahrene Spezialisten in Zürich',
+  description:
+    'Lernen Sie das triarc-Team kennen. Erfahrene, engagierte Spezialisten für Custom Software, Beratung und digitale Innovation in Zürich.',
 }
 
 export const landingMetadata: TriarcPageMetadata = {
-  title: 'Triarc Labs - Ihr Partner für Custom Softwareentwicklung',
-  metaTitle: '',
-  description: 'Platzhalter',
+  title: 'triarc laboratories – Custom Softwareentwicklung & digitale Transformation',
+  metaTitle: 'triarc laboratories – Ihr Partner für Custom Softwareentwicklung',
+  description:
+    'Ihre Digitalisierung – strukturiert, effizient, erfolgreich. Wir unterstützen Sie von der Idee bis zur Umsetzung mit massgeschneiderter Software, Beratung und Innovation aus Zürich.',
+  ogImage: 'https://triarc-labs.com/triarc-og-default.png',
 }

--- a/src/lib/index/Lab.svelte
+++ b/src/lib/index/Lab.svelte
@@ -10,7 +10,7 @@
       </div>
       <img src={labSvg} class="w-96 mx-auto" alt="triarc innovation lab" />
       <p class="text-xl leading-7 text-gray-200 max-w-xl mx-auto">
-        In unserem Lab wird laufend an neue Ideen gearbeitet und getüftelt. Wir versuchen dabei stehts Neues zu schaffen
+        In unserem Lab wird laufend an neuen Ideen gearbeitet und getüftelt. Wir versuchen dabei stets Neues zu schaffen
         in Zusammenarbeit mit lokalen Partnern.
       </p>
       <a href="/innovation" class="inline-block bg-black bg-opacity-50 px-6 py-2 rounded-md">Projekte entdecken</a>

--- a/src/lib/index/Technology.svelte
+++ b/src/lib/index/Technology.svelte
@@ -10,7 +10,7 @@
       <div class="space-y-5 sm:mx-auto sm:max-w-xl sm:space-y-4 lg:max-w-5xl">
         <h2 class="text-3xl leading-9 font-extrabold tracking-tight sm:text-4xl">Unsere Technologien</h2>
         <p class="text-xl leading-7">
-          Unsere Team bringen ein breites Fachwissen mit und beherrscht <span class="underline">fast</span>
+          Unser Team bringt ein breites Fachwissen mit und beherrscht <span class="underline">fast</span>
           alle gängigen Programmiersprachen. <br />
           Wir freuen uns auf deine Unterstützung in unseren Projekten, welche wir über mehrere Technologien hinweg zum Erfolg
           führen.

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -183,7 +183,7 @@
       en: "%c We're hiring! Checkout https://triarc-labs.com/jobs",
       de: '%c Wir suchen dich! https://triarc-labs.com/jobs',
       'de-DE': '%c Wir suchen dich! https://triarc-labs.com/jobs',
-      'de-CH': '%c Mir suched dich! https://triarc-labs.com/job s',
+      'de-CH': '%c Mir suched dich! https://triarc-labs.com/jobs',
     }
     const message = messages[navigator.language] || messages['en']
     console.log(

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -210,7 +210,55 @@
       video.play()
     }
   })
+
+  // BreadcrumbList JSON-LD – erzeugt Breadcrumbs aus dem aktuellen Pfad
+  $: breadcrumbSegments = getBreadcrumbSegments(data.pathname)
+
+  function getBreadcrumbSegments(pathname: string) {
+    if (pathname === '/') return []
+    const segments = pathname.split('/').filter(Boolean)
+    const items: { name: string; url: string }[] = []
+    let cumulativePath = ''
+    for (const segment of segments) {
+      cumulativePath += '/' + segment
+      const linkInfo = linkMetaInfo[cumulativePath]
+      items.push({
+        name: linkInfo?.title ?? segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' '),
+        url: `https://triarc-labs.com${cumulativePath}`,
+      })
+    }
+    return items
+  }
+
+  $: breadcrumbJsonLd =
+    breadcrumbSegments.length > 0
+      ? JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            {
+              '@type': 'ListItem',
+              position: 1,
+              name: 'Home',
+              item: 'https://triarc-labs.com',
+            },
+            ...breadcrumbSegments.map((seg, i) => ({
+              '@type': 'ListItem',
+              position: i + 2,
+              name: seg.name,
+              item: seg.url,
+            })),
+          ],
+        })
+      : ''
 </script>
+
+<svelte:head>
+  {#if breadcrumbJsonLd}
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -- Static JSON-LD -->
+    {@html `<script type="application/ld+json">${breadcrumbJsonLd}</script` + '>'}
+  {/if}
+</svelte:head>
 
 <ContactButton></ContactButton>
 <div id="page" class="content {menuOpen ? 'open' : 'closed'}">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,12 +3,42 @@
   import LandingMission from '$lib/index/LandingMission.svelte'
   import MetaHead from '$lib/components/MetaHead.svelte'
   import { landingMetadata } from '$lib/content/triarc-page-metadata'
+
+  const organizationSchema = JSON.stringify(
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      name: 'triarc laboratories Ltd.',
+      url: 'https://triarc-labs.com',
+      logo: 'https://triarc-labs.com/triarc-logo-black.svg',
+      contactPoint: {
+        '@type': 'ContactPoint',
+        telephone: '+41 44 279 10 00',
+        contactType: 'sales',
+        email: 'development@triarc-labs.com',
+        availableLanguage: ['German', 'English'],
+      },
+      sameAs: ['https://www.linkedin.com/company/triarc-laboratories-ltd/'],
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: 'Neue Hard 14',
+        addressLocality: 'Zürich',
+        addressRegion: 'ZH',
+        postalCode: '8005',
+        addressCountry: 'CH',
+      },
+    },
+    null,
+    2
+  )
 </script>
 
 <MetaHead pageMetadata={landingMetadata}></MetaHead>
-<!--<svelte:head>-->
-<!--  <title>Custom Softwareentwicklung Schweiz</title>-->
-<!--</svelte:head>-->
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- Static JSON-LD -->
+  {@html '<script type="application/ld+json">' + organizationSchema + '</script>'}
+</svelte:head>
 
 <Landing></Landing>
 <LandingMission></LandingMission>

--- a/src/routes/consulting/+page.svelte
+++ b/src/routes/consulting/+page.svelte
@@ -19,7 +19,7 @@
         'Der Mensch digitalisiert für die Menschen - wir stellen den User in den Mittelpunkt damit der Wandel von allen getragen und gelebt wird. Nur dann ist die Digitalisierung nachhaltig. ',
       person: 'Iris Zenegaglia',
       image: iris,
-      personTitle: 'Digitalisierungs/Organisationsberaterin <br> ' + 'Coach (bso i.A) <br> Partnerin',
+      personTitle: 'Digitalisierungs/Organisationsberaterin <br> ' + 'Coach (bso i. A.) <br> Partnerin',
       linkedin: 'https://www.linkedin.com/in/iriszenegagliagloor/',
       email: 'iris@triarc-labs.com',
       highlight: 'green',
@@ -34,12 +34,12 @@
         posts: data.posts.consulting as MappedPost[],
       },
       {
-        title: 'Analysieren sie ihr Digitalisierungspotential',
+        title: 'Analysieren Sie Ihr Digitalisierungspotenzial',
         content: '',
         posts: data.posts.potential as MappedPost[],
       },
       {
-        title: 'Visions-und Strategieentwicklung',
+        title: 'Visions- und Strategieentwicklung',
         content:
           'Für eine Transformation braucht es ein konkretes Zielbild. Wir entwickeln zusammen mit unseren Kunden eine Vision und Strategie ihrer Digitalisierung. Daraus entstehen Massnahmen für die konkrete Umsetzung und schlussendlich Erreichung des Zielbildes. So wird die massgeschneiderte Software für das ganze Unternehmen zum vollen Erfolg! ',
         posts: data.posts.vision as MappedPost[],
@@ -47,7 +47,7 @@
       {
         title: 'Change Management. Der Mensch steht im Mittelpunkt.',
         content:
-          'Eine Veränderung ist erst dann erfolgreich, wenn sie sich nachhaltig im Unternehmen verankert. Dabei spielen die Mitarbeiter eine zentrale Rolle. Nur mit einer gemeinsamen Vision und der Erkennung der Notwendigkeit blicken die Mitarbeiter der Veränderung motiviert entgegen. <br/><br/>Wir begleiten die Mitarbeiter durch die Transformation, nehmen ihr Ängste und Befürchtungen ernst, binden sie im Entwicklungsprozess mit ein und unterstützen sie bei der Einführung der neuen Technologie.',
+          'Eine Veränderung ist erst dann erfolgreich, wenn sie sich nachhaltig im Unternehmen verankert. Dabei spielen die Mitarbeiter eine zentrale Rolle. Nur mit einer gemeinsamen Vision und der Erkennung der Notwendigkeit blicken die Mitarbeiter der Veränderung motiviert entgegen. <br/><br/>Wir begleiten die Mitarbeiter durch die Transformation, nehmen ihre Ängste und Befürchtungen ernst, binden sie im Entwicklungsprozess mit ein und unterstützen sie bei der Einführung der neuen Technologie.',
         posts: data.posts.changeManagement as MappedPost[],
       },
       {
@@ -73,8 +73,8 @@
             source: 'Patric Masar von Helvetas',
             content:
               '«Dank der effizienten und zielorientierten Methodik konnten wir in nur zwei von Triarc moderierten halbtägigen Workshops ' +
-              'ein umfassendes Konzept für eine Zeiterfassunges und Spesenapp mit dem Erweiterungspotential für eine vielzahl weiterer ' +
-              'Anwendung erarbeiten. Neben dem definieren der Kernanforderungen haben wir in Brainstormingsessions auch Ideen für zukünftige ' +
+              'ein umfassendes Konzept für eine Zeiterfassungs- und Spesenapp mit dem Erweiterungspotential für eine Vielzahl weiterer ' +
+              'Anwendung erarbeiten. Neben dem Definieren der Kernanforderungen haben wir in Brainstormingsessions auch Ideen für zukünftige ' +
               'Anwendungsgebiete der App erarbeitet. Es ist erstaunlich welche Vielzahl an guten und realisierbaren Ideen daraus resultierten.»',
           },
         },
@@ -86,7 +86,7 @@
             source: 'Andrea Isler von Analytica',
             content:
               '«Dank der Organisationsanalyse der Firma Triarc konnten wir die komplexe Struktur unserer ICT-Organisation besser verstehen und in der Folge die Effizienz unserer Abläufe verbessern sowie deren Innovation fördern.' +
-              'Der didaktische Ansatz der Berater:innen einerseits Wissen zu vermitteln und andererseits unsere Fachkräfte persönlich zu coachen wurde als besonders gewinnbringend eingeschätzt.' +
+              'Der didaktische Ansatz der Berater:innen einerseits Wissen zu vermitteln und andererseits unsere Fachkräfte persönlich zu coachen, wurde als besonders gewinnbringend eingeschätzt.' +
               'Zusammenfassend beurteilt war der Einsatz der Firma Triarc für uns ein voller Erfolg.»',
           },
         },

--- a/src/routes/consulting/+page.svelte
+++ b/src/routes/consulting/+page.svelte
@@ -10,6 +10,8 @@
   import type { MappedPost } from './+page'
   import ContactForm from '$lib/components/ContactForm.svelte'
   import type { FeaturedContent } from '$lib/components/FeaturedContent'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { consultingMetadata } from '$lib/content/triarc-page-metadata'
 
   export let data
   export let contactString = 'Iris direkt kontaktieren'
@@ -94,6 +96,8 @@
     ],
   }
 </script>
+
+<MetaHead pageMetadata={consultingMetadata}></MetaHead>
 
 <svelte:head>
   <title>Beratung - triarc-labs</title>

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -4,6 +4,8 @@
   import heroImage from '$lib/assets/hero/Contact.jpg?width=300;600;1000;2000&format=webp&metadata&enhanced'
   import iris from '$lib/assets/team/iris.jpg?format=webp;png&w=500&enhanced'
   import serge from '$lib/assets/team/serge.jpg?format=webp;png&w=1024&enhanced'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { contactMetadata } from '$lib/content/triarc-page-metadata'
 
   let firstName = '',
     lastName = '',
@@ -32,6 +34,8 @@
     })
   }
 </script>
+
+<MetaHead pageMetadata={contactMetadata}></MetaHead>
 
 <svelte:head>
   <title>Kontakt - triarc-labs</title>

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -258,7 +258,7 @@
       <div class="py-16">
         <h2 class="text-2xl font-bold text-gray-900 sm:text-3xl sm:tracking-tight">Kontaktformular</h2>
         <h3 class="text-lg mt-3 font-medium text-gray-500">
-          Interessiert? Trete in Kontakt, damit wir gemeinsam Lösungen schaffen
+          Interessiert? Tritt in Kontakt, damit wir gemeinsam Lösungen schaffen
         </h3>
         <form action="#" method="POST" class="mt-6 grid grid-cols-1 gap-y-6 sm:grid-cols-2 sm:gap-x-8">
           <div>

--- a/src/routes/custom-software/+page.svelte
+++ b/src/routes/custom-software/+page.svelte
@@ -23,7 +23,7 @@
     {
       title: 'Lösungen entwickeln',
       content:
-        'Dank unserer jahrelangen Erfahrung und Knowhow sind wir in der Lage, einzigartige Lösungen zu entwickeln, die den Kunden helfen, ihre Ziele effizient und kosteneffektiv zu erreichen. Wir verstehen, dass jedes Unternehmen einzigartig ist und dass es keine "One-Size-Fits-All"-Lösungen gibt.<br/><br/>' +
+        'Dank unserer jahrelangen Erfahrung und unserem Know-how sind wir in der Lage, einzigartige Lösungen zu entwickeln, die den Kunden helfen, ihre Ziele effizient und kosteneffektiv zu erreichen. Wir verstehen, dass jedes Unternehmen einzigartig ist und dass es keine "One-Size-Fits-All"-Lösungen gibt.<br/><br/>' +
         'Unser Ziel ist es, unseren Kunden die besten und innovativsten Lösungen zu bieten, die ihnen dabei helfen, ihr Geschäft zu verbessern und ihre Wettbewerbsfähigkeit zu erhöhen.',
     },
     {
@@ -34,12 +34,12 @@
         {
           title: 'Concept',
           content:
-            'Zusammen erarbeiten wir Ziele sowie Anforderungen, welche erfüllt werden sollen. Gemeinsam erarbeitet durch Management, Mitarbeitern sowie unserer Projektleitung.',
+            'Zusammen erarbeiten wir Ziele sowie Anforderungen, welche erfüllt werden sollen. Gemeinsam erarbeitet durch das Management, die Mitarbeitenden sowie unsere Projektleitung.',
         },
         {
           title: 'Planning',
           content:
-            'Nach einer Aufarbeitung der Anforderungen und Einschätzung des Aufwands, werden Anforderungen zusammen mit dem Aufwand priorisiert, verschoben oder angepasst. Das Resultat ist ein Sprint mit Anforderungen von 100-180 Stunden Entwicklungsaufwand.',
+            'Nach einer Aufarbeitung der Anforderungen und Einschätzung des Aufwands werden Anforderungen zusammen mit dem Aufwand priorisiert, verschoben oder angepasst. Das Resultat ist ein Sprint mit Anforderungen von 100-180 Stunden Entwicklungsaufwand.',
         },
         {
           title: 'Entwicklung',
@@ -48,7 +48,7 @@
         {
           title: 'Review',
           content:
-            'Die Entwicklung ist abgeschlossen und das Resultat kann vom Kunden getestet werden. Sobald abgenommen, gehts direkt in den produktiven Betrieb und die Anwender dürfen sich über die neusten Änderungen freuen.',
+            'Die Entwicklung ist abgeschlossen und das Resultat kann vom Kunden getestet werden. Sobald abgenommen, geht es direkt in den produktiven Betrieb und die Anwender dürfen sich über die neuesten Änderungen freuen.',
         },
       ],
     },
@@ -84,7 +84,7 @@
         {
           title: 'Effizienzsteigerung',
           content:
-            'Durch die schrittweise Entwicklung und kontinuierlichem Testen werden Fehler und Fehlentwicklungen früh entdeckt und können sofort eliminiert werden.',
+            'Durch die schrittweise Entwicklung und kontinuierliches Testen werden Fehler und Fehlentwicklungen früh entdeckt und können sofort eliminiert werden.',
         },
         {
           title: 'Geringeres Risiko',
@@ -104,7 +104,7 @@
       content:
         'Der Betrieb sowie die Wartung unserer Software ist uns ein wichtiges Anliegen. Wir betreiben unsere Software flexibel in unserem Cloud Angebot oder auf deinen vorhandenen Servern.' +
         '<br/><br/>' +
-        'Regelmässige Wartung der Software sowie das Einspielen von sicherheitsrelevanten Patches ist für uns ein Routine-Job und läst uns Nachts besser schlafen.',
+        'Regelmässige Wartung der Software sowie das Einspielen von sicherheitsrelevanten Patches ist für uns ein Routine-Job und lässt uns nachts besser schlafen.',
       image: { src: maintenance, alt: 'Wartung' },
     },
   ]

--- a/src/routes/custom-software/+page.svelte
+++ b/src/routes/custom-software/+page.svelte
@@ -6,6 +6,8 @@
   import Footer from '$lib/components/Footer.svelte'
   import heroImage from '$lib/assets/hero/CustomSoftware.jpg?width=300;600;1000;2000&format=webp&metadata&enhanced'
   import type { BlockContent } from '$lib/components/TypeDefinitions'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { customSoftwareMetadata } from '$lib/content/triarc-page-metadata'
 
   let contents: BlockContent[] = [
     {
@@ -109,6 +111,8 @@
     },
   ]
 </script>
+
+<MetaHead pageMetadata={customSoftwareMetadata}></MetaHead>
 
 <svelte:head>
   <title>Custom Software - triarc-labs</title>

--- a/src/routes/future/+page.svelte
+++ b/src/routes/future/+page.svelte
@@ -2,6 +2,8 @@
   import ThemedSection from '$lib/index/ThemedSection.svelte'
   import type { PageData } from '../../../.svelte-kit/types/src/routes/operations/$types'
   import { futureSectionContent } from '$lib/content/future-section'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { futureMetadata } from '$lib/content/triarc-page-metadata'
 
   export let data: PageData
 
@@ -11,5 +13,7 @@
   }
   futureSectionContent
 </script>
+
+<MetaHead pageMetadata={{ futureMetadata }}></MetaHead>
 
 <ThemedSection sectionContent={subsection} sectionGradientColor="red-blue" sectionColor="blue"></ThemedSection>

--- a/src/routes/innovation/+page.svelte
+++ b/src/routes/innovation/+page.svelte
@@ -72,7 +72,7 @@
     {
       title: 'Fair Pizza',
       content:
-        'Fair Pizza bietet Restaurants eine einfache und günstige Alternative Angebot selbständig Online zu\n' +
+        'Fair Pizza bietet Restaurants eine einfache und günstige Alternative, ihr Angebot selbstständig online zu\n' +
         '              verkaufen. Die Whitelabel Lösung bietet eine Vielzahl von Konfigurationsmöglichkeiten inklusive einem\n' +
         '              Pizzabuilder. Mit Stripe lassen sich die Zahlungen bequem online abwickeln.',
 
@@ -83,8 +83,8 @@
       title: 'Slothi',
       content:
         'Slothi soll deine Terminprobleme lösen. Eine smarte Lösung, welche dir den passenden Termin für alle\n' +
-        '              Teilnehmer findet. \n\nDamit du möglichst einfach einen Termin planen kannst, wählst du den Zeitraum in welchem der Termin\n' +
-        '              stattfinden soll. Die erforderliche Zeitdauer und die Teilnehmer welche daran teilnehmen sollen. Ab da\n' +
+        '              Teilnehmer findet. \n\nDamit du möglichst einfach einen Termin planen kannst, wählst du den Zeitraum in dem der Termin\n' +
+        '              stattfinden soll. Die erforderliche Zeitdauer sowie die Teilnehmer, die daran teilnehmen sollen. Ab da\n' +
         '              übernimmt Slothi für dich und prüft die Verfügbarkeiten aller Teilnehmer. Du erhältst eine Auswahl an\n' +
         '              möglichen Terminvorschlägen und kannst einen fixen Termin einplanen.',
 

--- a/src/routes/innovation/+page.svelte
+++ b/src/routes/innovation/+page.svelte
@@ -11,6 +11,8 @@
   import slothiIcon from '$lib/assets/img/lab/slothi.svg'
   import heroImage from '$lib/assets/hero/InnovationLab.jpg?width=300;600;1000;2000&format=webp&metadata&enhanced'
   import type { BlockContent } from '$lib/components/TypeDefinitions'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { innovationMetadata } from '$lib/content/triarc-page-metadata'
 
   let contents: BlockContent[] = [
     {
@@ -93,6 +95,8 @@
     },
   ]
 </script>
+
+<MetaHead pageMetadata={innovationMetadata}></MetaHead>
 
 <svelte:head>
   <title>Innovation Lab - triarc-labs</title>

--- a/src/routes/jobs/+page.svelte
+++ b/src/routes/jobs/+page.svelte
@@ -10,6 +10,8 @@
   import CompanyAbout from '$lib/components/CompanyAbout.svelte'
   import { Initiativbewerbung, JobPostings } from '$lib/content/job-listings'
   import { DetailedJobListings } from '$lib/content/job-listings.js'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { jobsMetadata } from '$lib/content/triarc-page-metadata'
   const listedJob = 'Initiativbewerbung'
 
   function serializeSchema(jobPosting: JobPosting) {
@@ -86,6 +88,8 @@
   let initiativbewerbung = Initiativbewerbung
   let listings: DetailedJobListing[] = DetailedJobListings
 </script>
+
+<MetaHead pageMetadata={jobsMetadata}></MetaHead>
 
 <svelte:head>
   <title>Jobs - triarc-labs</title>

--- a/src/routes/jobs/+page.svelte
+++ b/src/routes/jobs/+page.svelte
@@ -39,7 +39,7 @@
             },
           },
           jobBenefits:
-            'Junges dynamisches Team. Modernste Technologien. Spannende Abwechslungsreiche Projekte. Soziokratie. Erfolgsbeteiligung. Grünes Open-Space Office mit Bar und Gym zentral in Zürich. Flexible Arbeitszeiten, Homeoffice und Remote. Innovation Lab, Agile Entwicklung',
+            'Junges dynamisches Team. Modernste Technologien. Spannende, abwechslungsreiche Projekte. Soziokratie. Erfolgsbeteiligung. Grünes Open-Space Office mit Bar und Gym zentral in Zürich. Flexible Arbeitszeiten, Homeoffice und Remote. Innovation Lab, Agile Entwicklung',
           datePosted: '2022-05-13',
           description: `Beschreibung: Triarc Labs sucht ${jobPosting.claim} 60 - 100%`,
           educationRequirements:
@@ -111,7 +111,7 @@
         <span class="block">Unsere Stellen</span>
       </h2>
       <p class="mt-4 text-lg leading-6">
-        Wir bieten unterschiedliche Stufen, in welcher du deine Karriere bei uns starten kannst.
+        Wir bieten unterschiedliche Stufen, auf denen du deine Karriere bei uns starten kannst.
       </p>
     </div>
   </div>

--- a/src/routes/jobs/[slug]/+page.svelte
+++ b/src/routes/jobs/[slug]/+page.svelte
@@ -11,6 +11,8 @@
   import { ourBenefits } from '$lib/content/benefits'
   import { ourApplicationProcess } from '$lib/content/application-process'
   import Container from '$lib/components/Container.svelte'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { jobsMetadata } from '$lib/content/triarc-page-metadata'
   export let data: PageData
 
   let benefits = ourBenefits
@@ -22,6 +24,8 @@
   let jobHero = jobListingBase.title!
   let jobTitle = jobListingBase.jobDetails!.jobName
 </script>
+
+<MetaHead pageMetadata={jobsMetadata}></MetaHead>
 
 <svelte:head>
   <title>Developer Job - triarc-labs</title>

--- a/src/routes/jobs/job-intro.svelte
+++ b/src/routes/jobs/job-intro.svelte
@@ -23,7 +23,7 @@
         'Together you succeed <br/><br/>' +
         'Werde Teil des Teams und bewirb dich, wenn du Leidenschaft, Elan und Tatendrang hast und du dich mit unseren <a class="underline decoration-red-triarc" href="/mission">Werten</a> identifizieren kannst. <br/> <br/>' +
         'Du arbeitest und kommunizierst gerne im Team. Das Neue begeistert dich. Du bist eine positiv eingestellte Persönlichkeit, allzeit bereit für neue Herausforderungen. <br/><br/>' +
-        'Lehrabschluss/HF/Bachelor/Master oder selbst beigebracht. Bei uns ist nichts strikt vorgegeben, wir evaluieren immer zu deiner Situation. ',
+        'Lehrabschluss/HF/Bachelor/Master oder selbst angeeignet. Bei uns ist nichts strikt vorgegeben, wir evaluieren immer zu deiner Situation. ',
       image: { src: adventurer, alt: 'Triarc Career' },
     },
   ]

--- a/src/routes/lab/+page.svelte
+++ b/src/routes/lab/+page.svelte
@@ -36,8 +36,8 @@
             </h1>
 
             <p class="mt-6 text-xl text-gray-500">
-              Willkommen im Lab von triarc. Hier erfährst du mehr zu den entstandenen Produkten, welche wir im Rahmen
-              des Labs entwickeln.
+              Willkommen im Lab von triarc. Hier erfährst du mehr über die entstandenen Produkte, die wir im Rahmen des
+              Labs entwickeln.
             </p>
           </div>
         </div>
@@ -61,8 +61,8 @@
               Teilnehmer findet.
             </p>
             <p class="mt-4 text-lg text-gray-300">
-              Damit du möglichst einfach einen Termin planen kannst, wählst du den Zeitraum in welchem der Termin
-              stattfinden soll. Die erforderliche Zeitdauer und die Teilnehmer welche daran teilnehmen sollen. Ab da
+              Damit du möglichst einfach einen Termin planen kannst, wählst du den Zeitraum in dem der Termin
+              stattfinden soll. Die erforderliche Zeitdauer sowie die Teilnehmer, die daran teilnehmen sollen. Ab da
               übernimmt Slothi für dich und prüft die Verfügbarkeiten aller Teilnehmer. Du erhältst eine Auswahl an
               möglichen Terminvorschlägen und kannst einen fixen Termin einplanen.
             </p>
@@ -96,12 +96,12 @@
             <h2 class="text-3xl font-extrabold tracking-tight text-red-600">Fair Pizza</h2>
 
             <p class="mt-4 text-lg text-gray-700 italic">
-              Fair Pizza bietet Restaurants eine einfache und günstige Alternative Angebot selbständig Online zu
+              Fair Pizza bietet Restaurants eine einfache und günstige Alternative, ihr Angebot selbstständig online zu
               verkaufen. Die Whitelabel Lösung bietet eine Vielzahl von Konfigurationsmöglichkeiten inklusive einem
               Pizzabuilder. Mit Stripe lassen sich die Zahlungen bequem online abwickeln.
             </p>
             <p class="mt-4 text-lg text-gray-500">
-              Die Auslieferung erfolgt über eigene Wege oder über einer unseren lokalen <a
+              Die Auslieferung erfolgt über eigene Wege oder über einen unserer lokalen <a
                 target="_blank"
                 class="underline"
                 href="https://www.ultrakurier.ch/"

--- a/src/routes/lab/+page.svelte
+++ b/src/routes/lab/+page.svelte
@@ -3,6 +3,8 @@
   import FairPizza from '$lib/assets/img/lab/fairpizza-dashboard.png?format=webp;png&w=500&enhanced'
   import Slothi from '$lib/assets/img/lab/slothi.png?format=webp;png&w=500&enhanced'
   import labImage from '$lib/assets/img/lab/lab.svg'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { labMetadata } from '$lib/content/triarc-page-metadata'
   let email = ''
   let submitted = false
 
@@ -20,6 +22,8 @@
     submitted = true
   }
 </script>
+
+<MetaHead pageMetadata={labMetadata}></MetaHead>
 
 <svelte:head>
   <title>Innovation Lab - triarc-labs</title>

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -30,7 +30,7 @@
     {
       title: 'Erfolgreich digitalisieren',
       content:
-        'Wir sind Ihr Partner für erfolgreiche Digitalisierungsprojekte. Software nach Mass, inklusive Strategieberatung und Change Management Begleitung; alles aus einem Haus.',
+        'Wir sind Ihr Partner für erfolgreiche Digitalisierungsprojekte. Software nach Mass, inklusive Strategieberatung und Change-Management-Begleitung – alles aus einem Haus.',
       video: {
         videoTitle: 'Triarc auf der Baustelle',
         videoId: 'baustelle',
@@ -71,7 +71,7 @@
     {
       title: 'Digitale Transformation ist menschlich ',
       content:
-        'Technologie ist nur ein Teil der digitalen Transformation. Wir betrachten den Prozess ganzheitlich und verbinden die Technologie mit den Menschen, der Unternehmenskultur, den Prozessen und Strategie Ihrer Organisation.',
+        'Technologie ist nur ein Teil der digitalen Transformation. Wir betrachten den Prozess ganzheitlich und verbinden die Technologie mit den Menschen, der Unternehmenskultur, den Prozessen und der Strategie Ihrer Organisation.',
       image: { src: goals, height: 271, alt: 'Gemeinsame Ziele' },
       link: { href: '/consulting', text: 'Beratung' },
     },
@@ -103,7 +103,7 @@
         highlight: 'blue',
         linkedin: 'https://www.linkedin.com/in/elke-engel-6761998/',
         content:
-          'Unsere Form der co-kreativen, agilen und ja, manchmal auch intensiven, direkten Zusammenarbeit ist ein grundlegender Erfolgsfaktor für digitale Resultate, die Sie weiterbringen. ',
+          'Unsere Form der co-kreativen, agilen und ja, manchmal auch intensiven und direkten Zusammenarbeit ist ein grundlegender Erfolgsfaktor für digitale Resultate, die Sie weiterbringen. ',
       },
     },
     {
@@ -122,7 +122,7 @@
         highlight: 'red',
         linkedin: 'https://www.linkedin.com/company/triarc-laboratories-ltd/',
         content:
-          'Denn wir lieben was wir tun, und dass wir das gemeinsam tun. So kommen Spass und Freude in der Zusammenarbeit mit triarc-labs garantiert nicht zu kurz.',
+          'Denn wir lieben, was wir tun, und dass wir das gemeinsam tun. So kommen Spass und Freude in der Zusammenarbeit mit triarc-labs garantiert nicht zu kurz.',
       },
     },
 

--- a/src/routes/mission/+page.svelte
+++ b/src/routes/mission/+page.svelte
@@ -13,6 +13,8 @@
   import teardown from '$lib/assets/img/custom-software/product_teardown.svg'
   import goals from '$lib/assets/img/intro/shared_goals.svg'
   import baustelle from '$lib/assets/img/thumbnail/baustelle-poster.png'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { missionMetadata } from '$lib/content/triarc-page-metadata'
 
   let contents: BlockContent[] = [
     {
@@ -179,6 +181,8 @@
     // },
   ]
 </script>
+
+<MetaHead pageMetadata={missionMetadata}></MetaHead>
 
 <svelte:head>
   <title>together you succeed - triarc-labs</title>

--- a/src/routes/mlink/+page.svelte
+++ b/src/routes/mlink/+page.svelte
@@ -14,6 +14,8 @@
   import orthoTeamLogo from '$lib/assets/img/customer/ortho-team-logo.svg'
   import kibagLogo from '$lib/assets/img/customer/kibag-logo.svg'
   import waloLogo from '$lib/assets/img/customer/walo-logo.svg'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { mlinkMetadata } from '$lib/content/triarc-page-metadata'
 
   let contents: BlockContent[] = [
     {
@@ -167,6 +169,8 @@
     },
   ]
 </script>
+
+<MetaHead pageMetadata={mlinkMetadata}></MetaHead>
 
 <svelte:head>
   <title>mLink Data Broker - triarc-labs</title>

--- a/src/routes/mlink/+page.svelte
+++ b/src/routes/mlink/+page.svelte
@@ -20,7 +20,7 @@
       title: 'μLink Datahub',
       content:
         'Die Schnittstellenlösung, welche ihre komplette Software-Infrastruktur unter einen Hut bringt! ERP, CRM, Disposition, Zeiterfassung, Projektsoftware, HR Suite, Lagerbewirtschaftung usw. sind mit µLink in einem einzigen digitalen Ökosystem vereint. <br/><br/>' +
-        'Unternehmen, die konsequent auf digitale Lösungen setzen, haben einen klaren Wettbewerbsvorteil. Dabei wird mithilfe unterschiedlicher Softwarelösungen ein Prozess nach dem anderen digitalisiert. Durch diese stetig wachsende und sich verändernde Ökosystem entsteht das Bedürfnis die Datenflüsse zu managen. <br/><br/>' +
+        'Unternehmen, die konsequent auf digitale Lösungen setzen, haben einen klaren Wettbewerbsvorteil. Dabei wird mithilfe unterschiedlicher Softwarelösungen ein Prozess nach dem anderen digitalisiert. Durch dieses stetig wachsende und sich verändernde Ökosystem entsteht das Bedürfnis die Datenflüsse zu managen. <br/><br/>' +
         'Essenziell sind dabei Bedürfnisse wie das Verhindern manueller Arbeitsschritte, die direkte Zusammenarbeit von Mitarbeitern über Systemgrenzen hinweg, sowie das schnelle Finden aller massgebenden Informationen in den angebundenen Softwarelösungen. µLink liefert dafür die hochmoderne und effiziente Lösung mit dem Fokus auf Echtzeitkommunikation und Sicherheit.',
       image: { src: mLinkTree, alt: 'mlink logo' },
     },
@@ -45,14 +45,14 @@
       title: 'Softwareökosystem',
       image: { src: mLinkDatenfluss, alt: 'mlink ecosystem' },
       content:
-        'Schritt um Schritt zur perfekten Schnittstelle. Bei der Digitalisierung von Geschäftsprozessen kommen meist mehrere Software Systeme zum Einsatz. Die Schnittstellen zwischen den verschiedenen Systemen mit unterschiedlichen Technologien stellt Unternehmen vor grosse Herausforderungen. µLink vereinfacht als zentrale Instanz die Schnittstellenproblematik, vernetzt die verschiedenen Systeme und ermöglicht damit die ' +
+        'Schritt für Schritt zur perfekten Schnittstelle. Bei der Digitalisierung von Geschäftsprozessen kommen meist mehrere Software Systeme zum Einsatz. Die Schnittstellen zwischen den verschiedenen Systemen mit unterschiedlichen Technologien stellt Unternehmen vor grosse Herausforderungen. µLink vereinfacht als zentrale Instanz die Schnittstellenproblematik, vernetzt die verschiedenen Systeme und ermöglicht damit die ' +
         'zentrale Bewirtschaftung der Schnittstellen. So kann mit minimalem Aufwand neue ' +
         'Software ins Ökosystem integriert oder bestehende abgelöst werden.',
     },
     {
       title: 'Monitoring',
       content:
-        'Mit µLink lassen sich die Datenflüsse zwischen Softwaresystemen zentral observieren. Bei einem Ausfall, einer Abnahme der Leistung oder weiterer konfigurierbarer Parameter kann proaktiv alarmiert werden. Über das Grafana-Dashboard lassen sich alle systemrelevanten Komponenten in Echtzeit über-wachen und visualisieren.',
+        'Mit µLink lassen sich die Datenflüsse zwischen Softwaresystemen zentral observieren. Bei einem Ausfall, einer Abnahme der Leistung oder weiterer konfigurierbarer Parameter kann proaktiv alarmiert werden. Über das Grafana-Dashboard lassen sich alle systemrelevanten Komponenten in Echtzeit überwachen und visualisieren.',
       image: { src: monitoring, alt: 'borders' },
     },
     {
@@ -95,9 +95,9 @@
         {
           title: 'Kosteneffizienz',
           content:
-            'Integratoren bewegen sich immer nur im Umfeld ihrer Applikation, somit fällt der grösste Teil der Einarbeitungskosten und Koordinationsaufwand weg. Wird ein angebotenes System ausgetauscht, muss nur die Schnittstelle zu µLInk entwickelt werden. \n' +
+            'Integratoren bewegen sich immer nur im Umfeld ihrer Applikation, somit fällt der grösste Teil der Einarbeitungskosten und Koordinationsaufwand weg. Wird ein angebotenes System ausgetauscht, muss nur die Schnittstelle zu µLink entwickelt werden. \n' +
             'Für diverse Applikationen bieten wir Standardmodule an und sind gewillt auf Kundenwunsch weitere zu erarbeiten. \n' +
-            'Das Lizenzmodel von µLink könnte nicht simpler sein. Module werden einmalig erworben, danach verwenden sie mLink so oft und mit so vielen Usern wie sie wollen.\n',
+            'Das Lizenzmodell von µLink könnte nicht simpler sein. Module werden einmalig erworben, danach verwenden Sie µLink so oft und mit so vielen Usern wie Sie wollen.\n',
         },
       ],
     },

--- a/src/routes/operations/+page.svelte
+++ b/src/routes/operations/+page.svelte
@@ -2,6 +2,8 @@
   import type { PageData } from './$types'
   import ThemedSection from '$lib/index/ThemedSection.svelte'
   import { operationSectionContent } from '$lib/content/operations-section'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { operationsMetadata } from '$lib/content/triarc-page-metadata'
 
   export let data: PageData
 
@@ -11,5 +13,7 @@
   }
   operationSectionContent
 </script>
+
+<MetaHead pageMetadata={operationsMetadata}></MetaHead>
 
 <ThemedSection sectionContent={subsection} sectionGradientColor="green-blue" sectionColor="green"></ThemedSection>

--- a/src/routes/operations/teamwerk/+page.svelte
+++ b/src/routes/operations/teamwerk/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import TriarcProject from '$lib/index/TriarcProject.svelte'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { operationsMetadata } from '$lib/content/triarc-page-metadata'
 </script>
+
+<MetaHead pageMetadata={{ operationsMetadata }}></MetaHead>
 
 <TriarcProject></TriarcProject>

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import type { PageData } from './$types'
   import TriarcProject from '$lib/index/TriarcProject.svelte'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { landingMetadata } from '$lib/content/triarc-page-metadata'
   export let data: PageData
 </script>
+
+<MetaHead pageMetadata={{ landingMetadata }}></MetaHead>
 
 <TriarcProject project={data.project}></TriarcProject>

--- a/src/routes/references/+page.svelte
+++ b/src/routes/references/+page.svelte
@@ -10,6 +10,8 @@
   import Partners from '$lib/index/Partners.svelte'
   import NavJump from '$lib/components/NavJump.svelte'
   import type { BlockContent } from '$lib/components/TypeDefinitions'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { landingMetadata } from '$lib/content/triarc-page-metadata'
 
   let content: BlockContent = {
     quote: {
@@ -23,6 +25,8 @@
     },
   }
 </script>
+
+<MetaHead pageMetadata={landingMetadata}></MetaHead>
 
 <svelte:head>
   <title>Lösungen - triarc-labs</title>

--- a/src/routes/references/+page.svelte
+++ b/src/routes/references/+page.svelte
@@ -30,7 +30,7 @@
 
 <Hero
   title="Lösungen"
-  content="Was haben wir vollbracht und woraus ist es entstanden"
+  content="Was wir vollbracht haben – und woraus es entstanden ist"
   image={heroImage}
   imageAlt="Triarc Reference Projects Header"
 />

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -4,7 +4,7 @@ import type { RequestHandler } from '@sveltejs/kit'
 declare const __BUILD_TIME__: string
 const LAST_MODIFIED = typeof __BUILD_TIME__ !== 'undefined' ? __BUILD_TIME__ : new Date().toISOString()
 
-const SITE_URL = 'https://www.triarc-labs.com'
+const SITE_URL = 'https://triarc-labs.com'
 const GHOST_SITEMAP = 'https://blog.triarc-labs.com/sitemap-posts.xml'
 const BASE_DIR = '/src/routes'
 const STORIES_DIR = 'stories'
@@ -76,9 +76,9 @@ const sitemap = (pages: string[], stories: ParsedUrl[]) => `<?xml version="1.0" 
       (page) => `
   <url>
     <loc>${SITE_URL}${page}</loc>
-    <changefreq>weekly</changefreq>
+    <changefreq>${page === '/' ? 'daily' : 'weekly'}</changefreq>
     <lastmod>${LAST_MODIFIED}</lastmod>
-    <priority>1</priority>
+    <priority>${page === '/' ? '1.0' : page === '/contact' || page === '/lab' ? '0.5' : '0.8'}</priority>
   </url>
   `
     )

--- a/src/routes/stories/+page.svelte
+++ b/src/routes/stories/+page.svelte
@@ -66,7 +66,7 @@
 
 <Hero
   title="Stories"
-  content="Erfahre mehr über uns, lese was uns beschäftigt und wir gerade tun!"
+  content="Erfahre mehr über uns, lies, was uns beschäftigt und was wir gerade tun!"
   image={heroImage}
   imageAlt="Triarc Stories Header"
 />

--- a/src/routes/stories/+page.svelte
+++ b/src/routes/stories/+page.svelte
@@ -10,6 +10,8 @@
   import heroImage from '$lib/assets/hero/Stories.jpg?width=300;600;1000;2000&format=webp&metadata&enhanced'
   import type { MappedPost } from '../consulting/+page'
   import { MasonryInfiniteGrid } from '@egjs/svelte-infinitegrid'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { storiesMetadata } from '$lib/content/triarc-page-metadata'
 
   export let data: PageData
   let pageNumber = 2 //
@@ -59,6 +61,8 @@
     return [...items, ...newPosts]
   }
 </script>
+
+<MetaHead pageMetadata={storiesMetadata}></MetaHead>
 
 <svelte:head>
   <title>Stories - triarc-labs</title>

--- a/src/routes/stories/[slug]/+page.svelte
+++ b/src/routes/stories/[slug]/+page.svelte
@@ -8,6 +8,8 @@
   import { goto, afterNavigate } from '$app/navigation'
   import { base } from '$app/paths'
   import { page } from '$app/stores'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { storiesMetadata } from '$lib/content/triarc-page-metadata'
 
   let previousPage: string = base
 
@@ -59,6 +61,8 @@
     goto(previousPage)
   }
 </script>
+
+<MetaHead pageMetadata={storiesMetadata}></MetaHead>
 
 <svelte:head>
   <title>{data.title} - triarc-labs</title>

--- a/src/routes/stories/day-at-triarc/+page.svelte
+++ b/src/routes/stories/day-at-triarc/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import teamCall from '$lib/assets/img/office/teamcall.png'
   import officeView from '$lib/assets/img/office/office_view.jpg'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { storiesMetadata } from '$lib/content/triarc-page-metadata'
 </script>
+
+<MetaHead pageMetadata={storiesMetadata}></MetaHead>
 
 <svelte:head>
   <title>Day at triarc - triarc-labs</title>

--- a/src/routes/stories/ortho/+page.svelte
+++ b/src/routes/stories/ortho/+page.svelte
@@ -5,6 +5,8 @@
   import applicationIPadViewImage from '$lib/assets/img/stories/ortho/application-iPad-view-1080.webp'
   import orthoLogo from '$lib/assets/img/stories/ortho/ortho-logo.png'
   import orthoTeamImage from '$lib/assets/img/stories/ortho/ortho-team.jpg'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { storiesMetadata } from '$lib/content/triarc-page-metadata'
   let scanBoxes = {
     image: scanBoxesImage,
     imageAlt: 'scan boxes',
@@ -22,6 +24,8 @@
     imageAlt: 'application close up view',
   }
 </script>
+
+<MetaHead pageMetadata={storiesMetadata}></MetaHead>
 
 <svelte:head>
   <title>Success stories - triarc-labs</title>

--- a/src/routes/stories/ortho/+page.svelte
+++ b/src/routes/stories/ortho/+page.svelte
@@ -195,7 +195,7 @@
       </div>
       <div class="relative text-base py-4 max-w-prose mx-auto lg:max-w-5xl lg:mx-0 lg:pr-72">
         <p class="text-lg text-gray-500">
-          «Dabei haben wir 1:1 mitbekommen, wieviel Kreativität, Erfahrung und Engagement bei der Umsetzung
+          «Dabei haben wir 1:1 mitbekommen, wie viel Kreativität, Erfahrung und Engagement bei der Umsetzung
           unterschiedlichster Anforderungen eingeflossen sind. Mit ein Grund dafür ist sicherlich, dass triarc-labs
           inhabergeführt ist.»
         </p>

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -2,6 +2,8 @@
   import type { PageData } from './$types'
   import ThemedSection from '$lib/index/ThemedSection.svelte'
   import { strategySectionContent } from '$lib/content/strategy-section'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { strategyMetadata } from '$lib/content/triarc-page-metadata'
 
   export let data: PageData
   const subsection = {
@@ -10,5 +12,7 @@
   }
   strategySectionContent
 </script>
+
+<MetaHead pageMetadata={strategyMetadata}></MetaHead>
 
 <ThemedSection sectionContent={subsection} sectionGradientColor="red-green" sectionColor="red"></ThemedSection>

--- a/src/routes/strategy/[slug]/+page.svelte
+++ b/src/routes/strategy/[slug]/+page.svelte
@@ -2,6 +2,8 @@
 <!--  import type { PageData } from './$types'-->
 <!--  import TriarcProject from '$lib/index/TriarcProject.svelte'-->
 <!--  export let data: PageData-->
-<!--</script>-->
+<!--</script>
+
+<MetaHead pageMetadata={{ strategyMetadata }}></MetaHead>-->
 
 <!--<TriarcProject></TriarcProject>-->

--- a/src/routes/team/+page.svelte
+++ b/src/routes/team/+page.svelte
@@ -3,6 +3,8 @@
   import Footer from '$lib/components/Footer.svelte'
   import Hero from '$lib/components/Hero.svelte'
   import Block from '$lib/components/Block.svelte'
+  import MetaHead from '$lib/components/MetaHead.svelte'
+  import { teamMetadata } from '$lib/content/triarc-page-metadata'
   import joinTheTeam from '$lib/assets/img/intro/content_team.svg'
   import heroImage from '$lib/assets/hero/Team.jpg?width=300;600;1000;2000&format=webp&enhanced'
 
@@ -16,9 +18,12 @@
   }
 </script>
 
+<MetaHead pageMetadata={teamMetadata}></MetaHead>
+
 <svelte:head>
   <title>Team - triarc-labs</title>
 </svelte:head>
+
 <Hero
   title="Unser Team"
   content="Wir lieben, was wir tun, und dass wir das gemeinsam tun.

--- a/src/routes/team/+page.svelte
+++ b/src/routes/team/+page.svelte
@@ -21,7 +21,7 @@
 </svelte:head>
 <Hero
   title="Unser Team"
-  content="Wir lieben was wir tun, und dass wir das gemeinsam tun.
+  content="Wir lieben, was wir tun, und dass wir das gemeinsam tun.
         Von der Vision bis zur Anwendung können Sie sich auf unsere Kompetenz und Konstanz verlassen.
         Sie werden von erfahrenen, engagierten Spezialisten persönlich begleitet."
   image={heroImage}


### PR DESCRIPTION
## Summary\n\nUmfassende SEO-Optimierung für triarc-labs.com:\n\n### Sprint 1 – Meta-Tags & OG/Twitter Cards\n- **MetaHead-Component erweitert**: og:type, og:image, og:locale=de_CH, twitter:card=summary_large_image, canonical URL\n- **Alle 14 Metadaten-Einträge** in triarc-page-metadata.ts mit echten, suchmaschinenoptimierten Titeln und Descriptions gefüllt (vorher fast alle leer)\n- **MetaHead auf allen 20+ Seiten** eingebunden (vorher nur auf der Landing Page)\n- TypeDefinitions um ogImage und canonicalUrl erweitert\n\n### Sprint 2 – Sitemap & Structured Data\n- Sitemap: www entfernt, abgestufte Prioritäten (Homepage 1.0/daily, Hauptseiten 0.8/weekly, Kontakt/Lab 0.5)\n- Organization JSON-LD auf der Landing Page (mit Logo, Adresse, Kontakt, Social Profiles)\n- robots.txt konsistent ohne www\n\n### Sprint 3 – Breadcrumbs & Feinschliff\n- BreadcrumbList JSON-LD global im Layout\n- Alt-Text für Fair Pizza korrigiert (war fälschlich "slothi")\n\n### Vorher/Nachher\n| | Vorher | Nachher |\n|---|---|---|\n| Meta-Descriptions | 1/14 Seiten (Platzhalter) | 14/14 Seiten mit echten Descriptions |\n| OG Tags | Nur 4 Felder auf Landing Page | Vollständig auf allen Seiten |\n| Twitter Cards | Keine | summary_large_image auf allen Seiten |\n| Canonical URLs | Keine | Global gesetzt |\n| Structured Data | Nur JobPosting | +Organization, +BreadcrumbList |\n| Sitemap Priorities | Alle 1.0 | Abgestuft (1.0 / 0.8 / 0.5) |\n\n## Test plan\n- [ ] Vercel preview\n- [ ] lint/build CI green