### PR TITLE
fix: align contact page tel: link with displayed number

### DIFF
--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -59,7 +59,7 @@
                   >
                 </div>
                 <div class="ml-3 text-base text-black">
-                  <a href="tel:+41789466951" class="decoration-red-triarc underline">+41 44 279 10 00</a>
+                  <a href="tel:+41442791000" class="decoration-red-triarc underline">+41 44 279 10 00</a>
                   <p class="mt-1">Mon-Fri 09:00 - 18:00</p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Updates the contact page `tel:` href from the old mobile number to `+41442791000` so it matches the visible label `+41 44 279 10 00`.

## Test plan
- [ ] Open `/contact` and confirm the phone label still reads `+41 44 279 10 00`
- [ ] Click/tap the phone link and confirm it dials `+41 44 279 10 00`


Made with [Cursor](https://cursor.com)